### PR TITLE
Update lstm_xsimd.tpp

### DIFF
--- a/RTNeural/lstm/lstm_xsimd.tpp
+++ b/RTNeural/lstm/lstm_xsimd.tpp
@@ -189,7 +189,7 @@ LSTMLayerT<T, in_sizet, out_sizet, sampleRateCorr>::prepare(T delaySamples)
 template <typename T, int in_sizet, int out_sizet, SampleRateCorrectionMode sampleRateCorr>
 void LSTMLayerT<T, in_sizet, out_sizet, sampleRateCorr>::reset()
 {
-    if(sampleRateCorr != SampleRateCorrectionMode::None)
+    if constexpr(sampleRateCorr != SampleRateCorrectionMode::None)
     {
         for(auto& x : ct_delayed)
             std::fill(x.begin(), x.end(), v_type {});


### PR DESCRIPTION
 a conditional expression that is always constant. 

The compiler suggests using 'if constexpr' instead of a regular if statement. The if constexpr is a C++17 feature that allows for compile-time branching based on template parameters.

The file in question is lstm_xsimd.tpp and the line number is 192.

